### PR TITLE
Add Streams, Pagination, Tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
-.PHONY: run
+.PHONY: run test
 run:
-	go run cmd/server/main.go
+	go run cmd/server/main.go -p 8080
+
+test:
+	bash ./test.sh

--- a/cmd/server/internal/handlers/api.go
+++ b/cmd/server/internal/handlers/api.go
@@ -10,3 +10,14 @@ type Buff struct {
 	Question string   `json:"question"`
 	Answers  []string `json:"answers"`
 }
+
+type CreateStream struct {
+	Name  string   `json:"name"`
+	Buffs []uint64 `json:"buffs"`
+}
+
+type Stream struct {
+	ID    uint64   `json:"id"`
+	Name  string   `json:"name"`
+	Buffs []uint64 `json:"buffs"`
+}

--- a/cmd/server/internal/handlers/buff.go
+++ b/cmd/server/internal/handlers/buff.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"encoding/json"
 	"fmt"
+	"log"
 	"net/http"
 	"strconv"
 
@@ -17,32 +18,39 @@ func (b *buffHandler) GetBuff(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "id")
 	if id == "" {
 		http.Error(w, "missing buff id in path", http.StatusBadRequest)
+		log.Print("[Error] missing buff id in path")
 		return
 	}
 
 	parsedid, err := strconv.ParseUint(id, 10, 64)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("failed to parse id, %v", err), http.StatusBadRequest)
+		log.Printf("[Error] failed to parse id, %v", err)
 		return
 	}
 
 	buff, err := b.store.GetBuff(parsedid)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("failed to get buff, %v", err), http.StatusInternalServerError)
+		log.Printf("[Error] failed to get buff, %v", err)
 		return
 	}
 
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(buff); err != nil {
 		http.Error(w, fmt.Sprintf("failed encode buff, %v", err), http.StatusInternalServerError)
+		log.Printf("[Error] failed encode buff, %v", err)
 		return
 	}
+
+	log.Printf("GetBuff request is ok: User-Agent - %v, IP-Address - %v", r.UserAgent(), IPAddress(r))
 }
 
 func (b *buffHandler) CreateBuff(w http.ResponseWriter, r *http.Request) {
 	var cbr CreateBuff
 	if err := json.NewDecoder(r.Body).Decode(&cbr); err != nil {
 		http.Error(w, fmt.Sprintf("failed to unmarshal request, %v", err), http.StatusBadRequest)
+		log.Printf("[Error] failed to unmarshal request, %v", err)
 		return
 	}
 
@@ -55,18 +63,23 @@ func (b *buffHandler) CreateBuff(w http.ResponseWriter, r *http.Request) {
 	id, err := b.store.SetBuff(buff)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("failed create buff, %v", err), http.StatusInternalServerError)
+		log.Printf("[Error] failed create buff, %v", err)
 		return
 	}
 
 	buff, err = b.store.GetBuff(id)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("failed to get buff, %v", err), http.StatusInternalServerError)
+		log.Printf("[Error] failed to get buff, %v", err)
 		return
 	}
 
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(buff); err != nil {
 		http.Error(w, fmt.Sprintf("failed encode buff, %v", err), http.StatusInternalServerError)
+		log.Printf("[Error] failed encode buff, %v", err)
 		return
 	}
+
+	log.Printf("CreateBuff request is ok: User-Agent - %v, IP-Address - %v", r.UserAgent(), IPAddress(r))
 }

--- a/cmd/server/internal/handlers/memstore.go
+++ b/cmd/server/internal/handlers/memstore.go
@@ -5,17 +5,32 @@ import (
 	"sync"
 )
 
-type inMemStore struct {
+// We have to store data, so expanding InMemoryStore with Stream storage. The storage is literaterally the same,
+// except type of stored data. We can't simply add more fields to the structure,
+// cause the different methods would share Counter and Mutex fields. Also, now adding new data types to store is much easier.
+
+type buffMemStore struct {
 	mu        *sync.RWMutex
-	idCounter uint64
+	IdCounter uint64
 	buffs     map[uint64]*Buff
 }
 
-func (i *inMemStore) GetBuff(id uint64) (*Buff, error) {
-	i.mu.RLock()
-	defer i.mu.RUnlock()
+type streamMemStore struct {
+	mu        *sync.RWMutex
+	IdCounter uint64
+	streams   map[uint64]*Stream
+}
 
-	b, ok := i.buffs[id]
+type inMemStore struct {
+	buffStore   *buffMemStore
+	streamStore *streamMemStore
+}
+
+func (i *inMemStore) GetBuff(id uint64) (*Buff, error) {
+	i.buffStore.mu.RLock()
+	defer i.buffStore.mu.RUnlock()
+
+	b, ok := i.buffStore.buffs[id]
 	if !ok {
 		return nil, errors.New("buff not found")
 	}
@@ -23,19 +38,59 @@ func (i *inMemStore) GetBuff(id uint64) (*Buff, error) {
 }
 
 func (i *inMemStore) SetBuff(b *Buff) (uint64, error) {
-	i.mu.Lock()
-	defer i.mu.Unlock()
+	i.buffStore.mu.Lock()
+	defer i.buffStore.mu.Unlock()
 
-	i.idCounter++
-	b.ID = i.idCounter
-	i.buffs[i.idCounter] = b
-	return i.idCounter, nil
+	i.buffStore.IdCounter++
+	b.ID = i.buffStore.IdCounter
+	i.buffStore.buffs[i.buffStore.IdCounter] = b
+	return i.buffStore.IdCounter, nil
+}
+
+func (i *inMemStore) GetStream(id uint64) (*Stream, error) {
+	i.streamStore.mu.RLock()
+	defer i.streamStore.mu.RUnlock()
+
+	s, ok := i.streamStore.streams[id]
+	if !ok {
+		return nil, errors.New("stream not found")
+	}
+	return s, nil
+
+}
+
+func (i *inMemStore) SetStream(s *Stream) (uint64, error) {
+	i.streamStore.mu.Lock()
+	defer i.streamStore.mu.Unlock()
+
+	i.streamStore.IdCounter++
+	s.ID = i.streamStore.IdCounter
+	i.streamStore.streams[i.streamStore.IdCounter] = s
+	return i.streamStore.IdCounter, nil
+
+}
+
+func (i *inMemStore) Count() (uint64, error) {
+	return i.streamStore.IdCounter, nil
+
+}
+
+func (i *inMemStore) Streams() (map[uint64]*Stream, error) {
+	return i.streamStore.streams, nil
+
 }
 
 func NewInMemStore() Store {
 	return &inMemStore{
-		mu:        &sync.RWMutex{},
-		idCounter: 0,
-		buffs:     make(map[uint64]*Buff),
+		&buffMemStore{
+			mu:        &sync.RWMutex{},
+			IdCounter: 0,
+			buffs:     make(map[uint64]*Buff),
+		},
+		&streamMemStore{
+			mu:        &sync.RWMutex{},
+			IdCounter: 0,
+			streams:   make(map[uint64]*Stream),
+		},
 	}
 }

--- a/cmd/server/internal/handlers/route.go
+++ b/cmd/server/internal/handlers/route.go
@@ -1,8 +1,15 @@
 package handlers
 
 import (
+	"fmt"
 	"github.com/go-chi/chi"
+	"net/http"
 )
+
+func defaultPage(w http.ResponseWriter, r *http.Request) {
+	fmt.Fprintf(w, "Works!")
+	return
+}
 
 func Routes(store Store) *chi.Mux {
 	r := chi.NewRouter()
@@ -11,9 +18,28 @@ func Routes(store Store) *chi.Mux {
 		store: store,
 	}
 
+	r.Route("/", func(r chi.Router) {
+		r.Get("/", defaultPage)
+	})
+
 	r.Route("/buff", func(r chi.Router) {
 		r.Get("/{id}", bh.GetBuff)
 		r.Post("/", bh.CreateBuff)
+	})
+
+	sh := streamHandler{
+		store: store,
+	}
+
+	r.Route("/stream", func(r chi.Router) {
+		r.Post("/", sh.CreateStream)
+		r.Get("/", defaultPage)
+		r.Get("/page={page:[0-9]+}", sh.ListStreams)
+
+		r.Route("/{id}", func(r chi.Router) {
+			r.Get("/", sh.GetStream)
+
+		})
 	})
 
 	return r

--- a/cmd/server/internal/handlers/store.go
+++ b/cmd/server/internal/handlers/store.go
@@ -5,6 +5,14 @@ type BuffStore interface {
 	SetBuff(*Buff) (id uint64, err error)
 }
 
+type StreamStore interface {
+	GetStream(id uint64) (*Stream, error)
+	SetStream(s *Stream) (uint64, error)
+	Count() (uint64, error)
+	Streams() (map[uint64]*Stream, error)
+}
+
 type Store interface {
 	BuffStore
+	StreamStore
 }

--- a/cmd/server/internal/handlers/stream.go
+++ b/cmd/server/internal/handlers/stream.go
@@ -1,0 +1,197 @@
+package handlers
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"strconv"
+
+	"github.com/go-chi/chi"
+)
+
+type streamHandler struct {
+	store Store
+}
+
+func (s *streamHandler) GetStream(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+
+	if id == "" {
+		http.Error(w, fmt.Sprintf("missing stream id in path"), http.StatusBadRequest)
+		log.Print("[Error] missing stream id in path")
+		return
+	}
+
+	parsedid, err := strconv.ParseUint(id, 10, 64)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("failed to parse id, %v", err), http.StatusBadRequest)
+		log.Printf("[Error] failed to parse id, %v", err)
+		return
+	}
+
+	stream, err := s.store.GetStream(parsedid)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("failed to get stream, %v", err), http.StatusInternalServerError)
+		log.Printf("[Error] failed to get stream, %v", err)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(stream); err != nil {
+		http.Error(w, fmt.Sprintf("failed encode stream, %v", err), http.StatusInternalServerError)
+		log.Printf("[Error] failed encode stream, %v", err)
+		return
+	}
+
+	log.Printf("GetStream request is ok: User-Agent - %v, IP-Address - %v", r.UserAgent(), IPAddress(r))
+
+}
+
+func (s *streamHandler) CreateStream(w http.ResponseWriter, r *http.Request) {
+	var csr CreateStream
+	if err := json.NewDecoder(r.Body).Decode(&csr); err != nil {
+		http.Error(w, fmt.Sprintf("failed to unmarshal request, %v", err), http.StatusBadRequest)
+		log.Printf("[Error] failed to unmarshal request, %v", err)
+		return
+	}
+
+	// User could send any data, for instance non-existing buff id,
+	// we are checking the id and if any of those doesn;t exist
+	// return error.
+
+	for _, b := range csr.Buffs {
+
+		_, err := s.store.GetBuff(b)
+		if err != nil {
+			http.Error(w, fmt.Sprintf("Wrong request: failed create stream, %v", err), http.StatusInternalServerError)
+			log.Printf("[Error] Wrong request: failed create stream, %v", err)
+			return
+
+		}
+
+	}
+
+	stream := &Stream{
+		ID:    0,
+		Name:  csr.Name,
+		Buffs: csr.Buffs,
+	}
+
+	id, err := s.store.SetStream(stream)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("failed create stream, %v", err), http.StatusInternalServerError)
+		log.Printf("[Error] failed create stream, %v", err)
+		return
+	}
+
+	stream, err = s.store.GetStream(id)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("failed to get stream, %v", err), http.StatusInternalServerError)
+		log.Printf("[Error] failed to get stream, %v", err)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(stream); err != nil {
+		http.Error(w, fmt.Sprintf("failed encode stream, %v", err), http.StatusInternalServerError)
+		log.Printf("[Error] failed encode stream, %v", err)
+		return
+	}
+
+	log.Printf("CreateStream request is ok: User-Agent - %v, IP-Address - %v", r.UserAgent(), IPAddress(r))
+
+}
+
+func (s *streamHandler) ListStreams(w http.ResponseWriter, r *http.Request) {
+
+	total, _ := s.store.Count()
+
+	if total == 0 {
+		http.Error(w, fmt.Sprintf("No Data"), http.StatusInternalServerError)
+		log.Printf("[Error] No Data, please fill a Memory Storage")
+		return
+
+	}
+
+	page := chi.URLParam(r, "page")
+	pageSize := r.URL.Query().Get("pagesize")
+
+	if page == "" {
+		page = "1"
+	}
+
+	if pageSize == "" {
+		pageSize = "25"
+	}
+
+	parsedPage, err := strconv.ParseUint(page, 10, 64)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("failed to parse page, %v", err), http.StatusBadRequest)
+		log.Printf("[Error] failed to parse page, %v", err)
+		return
+	}
+
+	parsedPageSize, err := strconv.ParseUint(pageSize, 10, 64)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("failed to parse pageSize, %v", err), http.StatusBadRequest)
+		log.Printf("[Error] failed to parse pageSize, %v", err)
+		return
+	}
+
+	if total+parsedPageSize < parsedPage*parsedPageSize {
+		http.Error(w, fmt.Sprintf("No Data"), http.StatusBadRequest)
+		log.Printf("[Warning] No Data, wrong Parameters")
+		return
+
+	}
+
+	index, _ := s.store.Streams()
+
+	keys := make([]uint64, 0, len(index))
+	values := make([]*Stream, 0, len(index))
+	for k, v := range index {
+		keys = append(keys, k)
+		values = append(values, v)
+	}
+
+	var stream *Stream
+
+	startPageEntry := parsedPage*parsedPageSize - parsedPageSize
+	endPageEntry := parsedPage * parsedPageSize
+
+	if endPageEntry > total {
+		endPageEntry = total
+
+	}
+
+	result := make([]map[string]interface{}, endPageEntry-startPageEntry)
+
+	if startPageEntry > endPageEntry {
+		log.Printf("[Error] Wrong Parameters")
+		return
+	}
+
+	for j, i := 0, startPageEntry; i < endPageEntry; i, j = i+1, j+1 {
+
+		stream, _ = s.store.GetStream(i + 1)
+
+		if stream != nil {
+
+			result[j] = map[string]interface{}{"name": stream.Name, "id": stream.ID}
+		}
+	}
+
+	pretty, err := json.MarshalIndent(result, "", "    ")
+	if err != nil {
+		http.Error(w, fmt.Sprintf("failed encode stream, %v", err), http.StatusInternalServerError)
+		log.Printf("[Error] failed encode stream, %v", err)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	fmt.Fprintf(w, string(pretty))
+
+	log.Printf("ListStreams request is ok: User-Agent - %v, IP-Address - %v", r.UserAgent(), IPAddress(r))
+
+}

--- a/cmd/server/internal/handlers/utils.go
+++ b/cmd/server/internal/handlers/utils.go
@@ -1,0 +1,11 @@
+package handlers
+
+import "net/http"
+
+func IPAddress(r *http.Request) string {
+	forwarded := r.Header.Get("X-FORWARDED-FOR")
+	if forwarded != "" {
+		return forwarded
+	}
+	return r.RemoteAddr
+}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -2,16 +2,25 @@ package main
 
 import (
 	"net/http"
+	"log"
+	"flag"
 
 	"github.com/buffup/GolangTechTask/cmd/server/internal/handlers"
+
 )
 
 func main() {
+
+    var port string
+    flag.StringVar(&port, "p", "8080", "Specify listening port. Default is 8080")
+    flag.Parse()
+
+	log.Print("Service is started, localhost:" + port)
 	// Replace with DB impl
 	store := handlers.NewInMemStore()
 
 	routes := handlers.Routes(store)
-	if err := http.ListenAndServe(":8080", routes); err != nil {
+	if err := http.ListenAndServe(":" + port, routes); err != nil {
 		panic(err)
 	}
 }

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+
+# Prep env
+
+red="\e[31m"
+green="\e[32m"
+reset="\e[0m"
+bold="\e[1m"
+
+# Running server
+echo -e "${bold}Running server${reset}"
+go run cmd/server/main.go -p 8080 &
+sleep 2
+
+PID=$!
+
+
+# Prepare Test data
+echo -e "${bold}Preparing Test Data${reset}"
+
+
+curl -X POST -d '{"question":"whos the man?", "answers": ["you", "me"]}' localhost:8080/buff -D -
+curl -X POST -d '{"question":"which country?", "answers": ["UK", "US", "RU"]}' localhost:8080/buff -D -
+curl -X POST -d '{"question":"which drink?", "answers": ["coffee", "vodka", "water"]}' localhost:8080/buff -D -
+
+
+curl -X POST --silent -o /dev/null -d '{"name":"stream1", "buffs": [1]}' localhost:8080/stream -D -
+curl -X POST --silent -o /dev/null -d '{"name":"stream2", "buffs": [2]}' localhost:8080/stream -D -
+curl -X POST --silent -o /dev/null -d '{"name":"stream3", "buffs": [3]}' localhost:8080/stream -D -
+curl -X POST --silent -o /dev/null -d '{"name":"stream4", "buffs": [1,2]}' localhost:8080/stream -D -
+curl -X POST --silent -o /dev/null -d '{"name":"stream5", "buffs": [1,3]}' localhost:8080/stream -D -
+curl -X POST --silent -o /dev/null -d '{"name":"stream6", "buffs": [2,3]}' localhost:8080/stream -D -
+curl -X POST --silent -o /dev/null -d '{"name":"stream7", "buffs": [3,2]}' localhost:8080/stream -D -
+curl -X POST --silent -o /dev/null -d '{"name":"stream8", "buffs": [3,1]}' localhost:8080/stream -D -
+curl -X POST --silent -o /dev/null -d '{"name":"stream9", "buffs": [1,2]}' localhost:8080/stream -D -
+curl -X POST --silent -o /dev/null -d '{"name":"stream10", "buffs": [1,3]}' localhost:8080/stream -D -
+curl -X POST --silent -o /dev/null -d '{"name":"stream11", "buffs": [1]}' localhost:8080/stream -D -
+curl -X POST --silent -o /dev/null -d '{"name":"stream12", "buffs": [2,1,3]}' localhost:8080/stream -D -
+curl -X POST --silent -o /dev/null -d '{"name":"stream13", "buffs": [3]}' localhost:8080/stream -D -
+curl -X POST --silent -o /dev/null -d '{"name":"stream14", "buffs": [1,3,2]}' localhost:8080/stream -D -
+curl -X POST --silent -o /dev/null -d '{"name":"stream15", "buffs": [2]}' localhost:8080/stream -D -
+curl -X POST --silent -o /dev/null -d '{"name":"stream16", "buffs": [3]}' localhost:8080/stream -D -
+curl -X POST --silent -o /dev/null -d '{"name":"stream17", "buffs": [1,3,2]}' localhost:8080/stream -D -
+curl -X POST --silent -o /dev/null -d '{"name":"stream18", "buffs": [2,1]}' localhost:8080/stream -D -
+curl -X POST --silent -o /dev/null -d '{"name":"stream19", "buffs": [3]}' localhost:8080/stream -D -
+curl -X POST --silent -o /dev/null -d '{"name":"stream20", "buffs": [1]}' localhost:8080/stream -D -
+
+
+# Test Get Stream
+
+if [ $(curl -s -o /dev/null -w "%{http_code}" -X GET  localhost:8080/stream/12) -eq 200 ]
+then
+    echo -e "${bold}===> Get Stream Test is ${green}Ok${reset}"
+else
+    echo -e "${bold}===> Get Stream Test is ${red}Failed${reset}"
+fi
+
+
+# Test Error
+if [ "x$(curl --silent -X GET  localhost:8080/stream/100 )" == "xfailed to get stream, stream not found" ]
+then
+    echo -e "${bold}===> Get Stream Error Test is ${green}Ok${reset}"
+else
+    echo -e "${bold}===> Get Stream Error Test is ${red}Failed${reset}"
+fi
+
+
+# Test Pagination List
+
+if [ $(curl --silent -X GET  localhost:8080/stream/page=2?pagesize=10 | grep id | wc -l) -eq 10 ]
+then
+    echo -e "${bold}===> Get Pagination List Test is ${green}Ok${reset}"
+else
+    echo -e "${bold}===> Get Pagination List Test is ${red}Failed${reset}"
+fi
+
+
+
+# Exit
+echo -e "${bold}Exiting...${reset}"
+kill -9 $PID
+ps aux | grep "main -p 8080" | grep -v grep |awk '{print $2}' | xargs -I{} kill -9 {} > /dev/null 2>&1
+
+


### PR DESCRIPTION
First of all I apologize for the delay. 

The test case:

1. I don't fully undertsand the correct way to attach buff to stream. Implemented through POST param with CreateStream endpoint. Second thought - separate endpoint for attaching. 
2. Tests for endpoints are simple with curl, just run  ```make test``` (Just an example, not fully handled). It's more kind integration tests rather than unit. (I don't see a sense for unit tests for endpoints) (also you can check how to explore the endpoints)
3. Unfortunately I dont implemented SQL interface. (time issue 😞 )Same for Compose. The test case took about 10 hours clear time. 

Implemented:

- Dafault page (to understand the server works)
- Rework routes, now /stream without id shows default page. (You can compare with /buff without id, it shows nothing)
- inmemory storage for Streams (second bucket with own Mutex and Map structure) 
- 3 endpoints: GetStream, CreateStream, ListStreams. 
- Logging (with User-Agent and IP-Address)
- Tests (with colouring, if you dont see colours, please update bash version)
- Port passed throuth app arg param (-p 8080)
- List of streams doesn't show buffs attached (according task example) and has pretty printing (again according task example)
- Pagination is dynamic, you can pass request params like /stream/page={N}?pagesize={N}
- Pagination could handle tail of last data. (with 100 items in memotry with page 9 and pagesize 12 shows last 4 entries)
- Handling corner cases, such empty data storage
- Default pagesize = 25

Ideally have to do:

- error output in JSON format.
- more gracefully user input handling
- Unit tests for inmemory storage 
- Rework inmemory storage, to reduce duplicated code (honestly, I missing pattern matching here)